### PR TITLE
Fixes for python 3.12

### DIFF
--- a/build-tools/Makefile
+++ b/build-tools/Makefile
@@ -116,11 +116,8 @@ pyoorb: ../lib/$(PYOORB_SO)
 		  echo "****************************************************************************"; \
 		  exit -1; \
 		}
-	@ [[ ! -z "$(LDFLAGS)" ]] && echo "$$LDFLAGS" | grep -E -v -q -- "(-bundle|-shared)" && { \
-	  [[ `uname` == "Darwin" ]] && LDFLAGS="$$LDFLAGS -bundle" || LDFLAGS="$$LDFLAGS -shared"; \
-	}; \
 	F77= $(F2PY) --quiet -m pyoorb pyoorb.o pyoorb.pyf ../lib/liboorb.a --build-dir ./_pyoorb_build -c --noarch \
-	        $(F2PY_FCOMPILER) --f90exec=$(FC) --f90flags="$(FC_INC)../build $(FCOPTIONS)" $(ADDLIBS) && \
+	       "$(FC_INC)$(ROOT_DIR)/build" $(F2PY_FCOMPILER) --f90exec=$(FC) --f90flags="$(FC_INC)../build $(FCOPTIONS)" $(ADDLIBS) && \
 	mv $(PYOORB_SO) ../python
 	@ echo
 	@ # FIXME: this exists so `sudo make install` knows what to install. It's hacky this way


### PR DESCRIPTION
1. f2py's meson variant (in use for >=3.12) will fail if -bundle is set. It will attempt to pass it for ALL linking, including meson's sanity test executables - and bundles are dynamic libraries, not executables.
2. f2py was not finding the include path for the built .mod files when using meson.